### PR TITLE
修复两处手机号格式校验的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ node_modules/*
 
 **/.vscode/**
 *.vscode
+**/.idea/**
+*.idea
 
 # Use yarn
 package-lock.json

--- a/src/components/newCustomFields/components/WidgetsVerifyCode.jsx
+++ b/src/components/newCustomFields/components/WidgetsVerifyCode.jsx
@@ -42,7 +42,7 @@ export default class WidgetsVerifyCode extends Component {
       isAvailable = false;
     } else {
       this.iti.setNumber(value);
-      if (!(this.iti.isValidNumber() || specialTelVerify(value))) {
+      if (!this.iti.isValidNumber() || !specialTelVerify(value)) {
         isAvailable = false;
       }
     }

--- a/src/pages/accountLogin/redux/actions.js
+++ b/src/pages/accountLogin/redux/actions.js
@@ -130,7 +130,7 @@ export const isValid = (isForSendCode, keys = [], type) => {
         };
         //手机号验证
         const isTelRule = () => {
-          if (!iti.isValidNumber() && !specialTelVerify(iti.getNumber())) {
+          if (!iti.isValidNumber() || !specialTelVerify(iti.getNumber())) {
             warnningData.push({ tipDom: '#txtMobilePhone', warnningText: _l('手机号格式错误') });
             isRight = false;
           }


### PR DESCRIPTION
## 现象
这是在登录明道云的时候偶然发现的：
![image](https://github.com/user-attachments/assets/b6ea8d04-edf6-4d5e-8840-a35077c09094)

## 修改理由
`iti.isValidNumber()` 看着是 [@mdfe/intl-tel-input](https://www.npmjs.com/package/@mdfe/intl-tel-input) 提供的校验能力。我看它底层的 [utils.js](http://libphonenumber/) 也是基于 [libphonenumber](https://github.com/google/libphonenumber) 实现的，可能确实就是这个底层库有问题吧，但后面的 [`specialTelVerify()`](https://github.com/mingdaocom/pd-openweb/blob/0a403c784fd3b3435976e29c633d9bd42922cb3b/src/pages/accountLogin/util.js#L11) 是能正常校验的。
![image](https://github.com/user-attachments/assets/a7ae7126-64b0-4830-961a-2ae90c9824c9)

所以我认为 [`src/pages/accountLogin/redux/actions.js#L133/isTelRule`](https://github.com/mingdaocom/pd-openweb/blob/0a403c784fd3b3435976e29c633d9bd42922cb3b/src/pages/accountLogin/redux/actions.js#L133) 这里不应该用 `&&` 逻辑，而应该用 `||` 逻辑。

还有一处使用 `specialTelVerify()` 的地方也是同理，我也顺便改了。

如果我上面想的不对的话还烦请指出并关闭PR，谢谢~

